### PR TITLE
[#37] 페이지 이동 시 스크롤 위치 상단에 위치

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { BrowserRouter, Route, Switch } from 'react-router-dom';
 import Header from './components/Header';
+import UseScrollTop from './hooks/useScrollTop';
 import {
   JoinPage,
   LoginPage,
@@ -18,6 +19,7 @@ import GlobalStyle from './styles/globalStyles';
 function App() {
   return (
     <BrowserRouter>
+      <UseScrollTop />
       <GlobalStyle />
       <Header />
       <Switch>

--- a/src/api/product.ts
+++ b/src/api/product.ts
@@ -25,7 +25,6 @@ export const loadProductsBest = async () => {
   if (response.status !== 200) {
     throw response.status;
   }
-  console.log('res', response);
   return response.data;
 };
 
@@ -34,7 +33,6 @@ export const loadProduct = async (id: number) => {
   if (response.status !== 200) {
     throw response.status;
   }
-  console.log('res', response);
   return response.data;
 };
 
@@ -52,6 +50,5 @@ export const searchProduct = async (
   if (response.status !== 200) {
     throw response.status;
   }
-  console.log('res', response);
   return response.data;
 };

--- a/src/hooks/useScrollTop.ts
+++ b/src/hooks/useScrollTop.ts
@@ -1,0 +1,12 @@
+import { useEffect } from 'react';
+import { useLocation } from 'react-router-dom';
+
+export default function UseScrollToTop() {
+  const { pathname } = useLocation();
+
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, [pathname]);
+
+  return null as null;
+}

--- a/src/pages/ProductDetailPage.tsx
+++ b/src/pages/ProductDetailPage.tsx
@@ -37,7 +37,6 @@ const ProductDetailPage = () => {
       history.push('/login');
     }
     const response = await likeProduct(Number(id));
-    console.log('resres', response);
     if (response === null) {
       return;
     }

--- a/src/utils/sortData.ts
+++ b/src/utils/sortData.ts
@@ -1,0 +1,4 @@
+import { GoodsProps } from './../types/goods';
+export const sortLikeList = (product: GoodsProps[]) => {
+    
+};


### PR DESCRIPTION
## 관련 이슈

#37 

## 구현 내용

####  useScrollTop 커스텀 훅 구현 
- react-router의 useLocation hook을 사용해서 location 객체에 접근 해서  location의 pathname 을 이용해 페이지 이동이 감지가 되면 window객체의 scrollTo 속성을 (0,0)으로 설정


- useScrollTop 커스텀 훅을 실제 페이지를 구성하는 페이지 상단에 위치
- useScrollTop 은 페이지 정보를 사용해야 하므로 react-router의 라우팅 설정 컴포넌트의 하위에 위치

```javascript
   <BrowserRouter>
      <UseScrollTop />
      <Switch>
        <Route path="/" exact component={MainPage} />
        .....
```