### PR TITLE
[#44] 서치바 debounce() 적용

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@types/styled-components": "^5.1.25",
     "axios": "^0.22.0",
     "compressorjs": "^1.1.1",
+    "loadsh": "^0.0.4",
     "react": "^17.0.2",
     "react-daum-postcode": "^3.0.0",
     "react-dom": "^17.0.2",
@@ -57,7 +58,8 @@
       "last 1 safari version"
     ]
   },
-  "devDependencies": {
+  "devDependencies": { 
+    "@types/lodash": "^4.14.182",
     "cra-bundle-analyzer": "^0.1.1"
   }
 }

--- a/src/components/Search/SearchBar.tsx
+++ b/src/components/Search/SearchBar.tsx
@@ -2,17 +2,17 @@ import React, { useCallback } from 'react';
 import styled from 'styled-components';
 import { useHistory } from 'react-router';
 import SearchIcon from '../common/icons/SearchIcon';
+import { debounce } from 'lodash';
 
 const SearchBar = () => {
   const history = useHistory();
 
-  const handleSearch = async (keyword: string) => {
+  const handleSearch = debounce((keyword: string) => {
     history.push({
       pathname: '/searchProduct',
       state: keyword,
     });
-    // window.location.reload();
-  };
+  }, 1000);
 
   const onKeyUp = useCallback((e) => {
     const keyword = e.target.value;


### PR DESCRIPTION
## 구현 내용 

기존에 서치바에 검색어를 입력하고 엔터를 계속 누르면 통신이 계속 되는 현상

![screen-recording](https://user-images.githubusercontent.com/70426440/183253904-f8612fd6-5766-44ba-83a5-f8af23eadc6e.gif)


lodash 라이브러리의 debounce()를 사용해서 함수가 호출되는 속도를 제한해 불필요하게 호출이 자주 일어나지 않도록 개선